### PR TITLE
Update link to instagram.com/wirelesshippie/ which had no https://

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -26,5 +26,5 @@ If you want to talk, hit me up! I'd love to talk with like minded people. I'm ba
 {: refdef}
 
 {:refdef: style="text-align: center;"}
-I have an [Instagram](instagram.com/wirelesshippie/) but I'm also available by email: [mariana@psychonautgirl.space](mariana@psychonautgirl.space).
+I have an [Instagram](https://instagram.com/wirelesshippie/) but I'm also available by email: [mariana@psychonautgirl.space](mariana@psychonautgirl.space).
 {: refdef}


### PR DESCRIPTION
Hi there,
I liked your blog, and I saw that the [this page](https://wireless-hippie.github.io/about) has a link to instagram.com/wirelesshippie/ which pointed to https://wireless-hippie.github.io/instagram.com/wirelesshippie/
This fixes it.